### PR TITLE
added 2 gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source 'https://rubygems.org'
 
+gem 'turbolinks'
+gem 'sprockets', '3.7.2'
 gem 'rails', '5.0.7.1'
 gem 'coffee-rails'
 gem 'jquery-rails'


### PR DESCRIPTION
This is to add 2 gems to fix errors in this lab.

The first is the sprockets gem. This is an issue that was just updated by adding a file in app/assets/config/manifest.js

The other way to handle this is to fix sprockets to a version less than 4.0

The second is turbolinks. I get a missing turbolinks error without this gem when I run learn.

Both added here.